### PR TITLE
Now downloading pictures in parallel

### DIFF
--- a/himawaripy.py
+++ b/himawaripy.py
@@ -11,22 +11,33 @@ from urllib.request import urlopen
 from PIL import Image
 
 from utils import get_desktop_environment
+from multiprocessing import Pool, cpu_count
+from itertools import product
 
 # Configuration
 # =============
 
 # Increases the quality and the size. Possible values: 4, 8, 16, 20
 level = 4
+width = 550
+height = 550
 
 # Path to the output file
 output_file = expanduser("~/.himawari/himawari-latest.png")
 
 # ==============================================================================
 
-def main():
-    width = 550
-    height = 550
+def download_chunk(args):
+    x, y, latest = args
+    url_format = "http://himawari8.nict.go.jp/img/D531106/{}d/{}/{}_{}_{}.png"
 
+    with urlopen(url_format.format(level, width, strftime("%Y/%m/%d/%H%M%S", latest), x, y)) as tile_w:
+        tiledata = tile_w.read()
+
+    return (x, y,tiledata)
+
+
+def main():
     print("Updating...")
     with urlopen("http://himawari8-dl.nict.go.jp/himawari8/img/D531106/latest.json") as latest_json:
         latest = strptime(loads(latest_json.read().decode("utf-8"))["date"], "%Y-%m-%d %H:%M:%S")
@@ -37,17 +48,13 @@ def main():
 
     png = Image.new('RGB', (width*level, height*level))
 
-    print("Downloading tiles: 0/{} completed".format(level*level), end="\r")
-    for x in range(level):
-        for y in range(level):
-            with urlopen(url_format.format(level, width, strftime("%Y/%m/%d/%H%M%S", latest), x, y)) as tile_w:
-                tiledata = tile_w.read()
+    p = Pool(cpu_count() * level)
+    res = p.map(download_chunk, product(range(level), range(level), (latest,)))
 
+
+    for (x, y, tiledata) in res:
             tile = Image.open(BytesIO(tiledata))
             png.paste(tile, (width*x, height*y, width*(x+1), height*(y+1)))
-
-            print("Downloading tiles: {}/{} completed".format(x*level + y + 1, level*level), end="\r")
-    print("\nDownloaded\n")
 
     makedirs(split(output_file)[0], exist_ok=True)
     png.save(output_file, "PNG")


### PR DESCRIPTION
Download pictures in parallel using a multiprocessing.Pool
Here is a comparison between the synchronous and parallel implementation.
Time was measured in seconds using the time command.

| Levels | Pool | Synchronous | Speed increase |
| --- | --- | --- | --- |
| 4 | 8 | 54 | 6.7 |
| 8 | 15 | 207 | 13.8 |
| 16 | 36 | 772 | 21.4 |
