### PR TITLE
Fill the background of black

### DIFF
--- a/himawaripy.py
+++ b/himawaripy.py
@@ -76,6 +76,7 @@ def main():
             call(["gsettings", "set", "org.gnome.desktop.background", "draw-background", "false"])
         call(["gsettings", "set", "org.gnome.desktop.background", "picture-uri", "file://" + output_file])
         call(["gsettings", "set", "org.gnome.desktop.background", "picture-options", "scaled"])
+        call(["gsettings", "set", "org.gnome.desktop.background", "primary-color", "FFFFFF"])
     elif de == "mate":
         call(["gsettings", "set", "org.mate.background", "picture-filename", output_file])
     elif de == "xfce4":


### PR DESCRIPTION
I don't know if other DE do the same but with Cinnamon every time I update the desktop image the background primary color change to blue.
With this line you can be sure that the background fill color will always be black (avoiding ugly vertical bars on the side)
