### PR TITLE
Added support for simple window managers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp   # vim temp files
 __*     # Ignoring __pycache__/ and other crap
+__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.swp   # vim temp files
+__*     # Ignoring __pycache__/ and other crap

--- a/himawaripy.py
+++ b/himawaripy.py
@@ -84,7 +84,7 @@ def main():
         call(["display", "-window", "root", output_file])
     elif de == "use_feh":
         print("\nYou seem to be using linux without a DE; Attempting to set backgroud with feh\n")
-        call(["feh", "--bg-fill", output_file])
+        call(["feh", "--bg-max", output_file])
     else:
         exit("Your desktop environment '{}' is not supported.".format(de))
 

--- a/himawaripy.py
+++ b/himawaripy.py
@@ -82,6 +82,8 @@ def main():
         call(["xfconf-query", "--channel", "xfce4-desktop", "--property", "/backdrop/screen0/monitor0/image-path", "--set", output_file])
     elif de == "lxde":
         call(["display", "-window", "root", output_file])
+    elif de == "use_feh":
+        call(["feh", "--bg-fill", output_file])
     else:
         exit("Your desktop environment '{}' is not supported.".format(de))
 

--- a/himawaripy.py
+++ b/himawaripy.py
@@ -83,6 +83,7 @@ def main():
     elif de == "lxde":
         call(["display", "-window", "root", output_file])
     elif de == "use_feh":
+        print("\nYou seem to be using linux without a DE; Attempting to set backgroud with feh\n")
         call(["feh", "--bg-fill", output_file])
     else:
         exit("Your desktop environment '{}' is not supported.".format(de))

--- a/utils.py
+++ b/utils.py
@@ -62,7 +62,7 @@ def get_desktop_environment():
             return "cinnamon"
         # We seem to be running linux without a DM. Chances we are running 
         # a tiling WM. Let's use feh to set the background.
-    else:
+    elif has_program("feh"):
             return "use_feh"
 
     return "unknown"
@@ -74,3 +74,9 @@ def is_running(process):
     except subprocess.CalledProcessError:
         return False
 
+def has_program(program):
+    try:
+        subprocess.check_output(["which", "--", program])
+        return True
+    except subprocess.CalledProcessError:
+        return False

--- a/utils.py
+++ b/utils.py
@@ -60,6 +60,10 @@ def get_desktop_environment():
             return "xfce4"
         elif current_desktop == "x-cinnamon":
             return "cinnamon"
+        # We seem to be running linux without a DM. Chances we are running 
+        # a tiling WM. Let's use feh to set the background.
+    else:
+            return "use_feh"
 
     return "unknown"
 


### PR DESCRIPTION
I added support for systems without DMs (ie WMs like DWM/Awesome/i3). If all other conditions fail I assume that we are running a simple WM and use feh to set the wallpaper. It also does not require any additional flags to be set.

Also, you should consider tossing a license in your repo when you get around to it (MIT might be a good choice). :)
