### PR TITLE
PEP8 + use cache directory convention

### DIFF
--- a/himawaripy/config.py
+++ b/himawaripy/config.py
@@ -1,4 +1,6 @@
-from os.path import expanduser
+import os.path
+
+import appdirs
 
 # Increases the quality and the size. Possible values: 4, 8, 16, 20
 level = 4
@@ -12,7 +14,9 @@ auto_offset = True
 hour_offset = 0
 
 # Path to the output file
-output_file = expanduser("~/.himawari/himawari-latest.png")
+output_file = os.path.join(appdirs.user_cache_dir(appname="himawaripy",
+                                                  appauthor=False),
+                           "latest.png")
 
 # Xfce4 displays to change the background of
 xfce_displays = ["/backdrop/screen0/monitor0/image-path",

--- a/himawaripy/himawaripy.py
+++ b/himawaripy/himawaripy.py
@@ -6,7 +6,7 @@ from itertools import product
 from json import loads
 from multiprocessing import Pool, cpu_count, Value
 from os import makedirs
-from os.path import split
+from os.path import dirname
 from time import strptime, strftime, mktime
 from urllib.request import urlopen
 
@@ -91,13 +91,14 @@ def main():
         tile = Image.open(BytesIO(tiledata))
         png.paste(tile, (width * x, height * y, width * (x + 1), height * (y + 1)))
 
-    makedirs(split(output_file)[0], exist_ok=True)
+    print("\nSaving to '%s'..." % (output_file))
+    makedirs(dirname(output_file), exist_ok=True)
     png.save(output_file, "PNG")
 
     if not set_background(output_file):
-        exit("\nYour desktop environment '{}' is not supported.".format(get_desktop_environment()))
+        exit("Your desktop environment '{}' is not supported.".format(get_desktop_environment()))
 
-    print("\nDone!")
+    print("Done!")
 
 if __name__ == "__main__":
     main()

--- a/himawaripy/himawaripy.py
+++ b/himawaripy/himawaripy.py
@@ -55,7 +55,7 @@ def download_chunk(args):
 
     with counter.get_lock():
         counter.value += 1
-        print("\rDownloading tiles: {}/{} completed".format(counter.value, level*level), end="", flush=True)
+        print("\rDownloading tiles: {}/{} completed".format(counter.value, level * level), end="", flush=True)
     return x, y, tiledata
 
 
@@ -80,16 +80,16 @@ def main():
 
     print()
 
-    png = Image.new('RGB', (width*level, height*level))
+    png = Image.new('RGB', (width * level, height * level))
 
     counter = Value("i", 0)
     p = Pool(cpu_count() * level)
-    print("Downloading tiles: 0/{} completed".format(level*level), end="", flush=True)
+    print("Downloading tiles: 0/{} completed".format(level * level), end="", flush=True)
     res = p.map(download_chunk, product(range(level), range(level), (requested_time,)))
 
     for (x, y, tiledata) in res:
         tile = Image.open(BytesIO(tiledata))
-        png.paste(tile, (width*x, height*y, width*(x+1), height*(y+1)))
+        png.paste(tile, (width * x, height * y, width * (x + 1), height * (y + 1)))
 
     makedirs(split(output_file)[0], exist_ok=True)
     png.save(output_file, "PNG")

--- a/himawaripy/utils.py
+++ b/himawaripy/utils.py
@@ -54,12 +54,12 @@ def get_desktop_environment():
         return "windows"
     elif sys.platform == "darwin":
         return "mac"
-    else: # Most likely either a POSIX system or something not much common
+    else:  # Most likely either a POSIX system or something not much common
         desktop_session = os.environ.get("DESKTOP_SESSION")
-        if desktop_session is not None: # Easier to match if we don't have to deal with caracter cases
+        if desktop_session is not None:  # Easier to match if we don't have to deal with caracter cases
             desktop_session = desktop_session.lower()
             if desktop_session in ["gnome", "unity", "cinnamon", "mate", "xfce4", "lxde", "fluxbox",
-                                   "blackbox", "openbox", "icewm", "jwm", "afterstep","trinity", "kde", "pantheon",
+                                   "blackbox", "openbox", "icewm", "jwm", "afterstep", "trinity", "kde", "pantheon",
                                    "gnome-classic"]:
                 return desktop_session
             ## Special cases ##
@@ -73,9 +73,9 @@ def get_desktop_environment():
                 return "lxde"
             elif desktop_session.startswith("kubuntu"):
                 return "kde"
-            elif desktop_session.startswith("razor"): # e.g. razorkwin
+            elif desktop_session.startswith("razor"):  # e.g. razorkwin
                 return "razor-qt"
-            elif desktop_session.startswith("wmaker"): # e.g. wmaker-common
+            elif desktop_session.startswith("wmaker"):  # e.g. wmaker-common
                 return "windowmaker"
         if os.environ.get('KDE_FULL_SESSION') == 'true':
             return "kde"
@@ -114,7 +114,7 @@ def has_program(program):
 
 def is_running(process):
     try:
-        subprocess.check_output (["pidof", "--", process])
+        subprocess.check_output(["pidof", "--", process])
         return True
     except subprocess.CalledProcessError:
         return False

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     description='Put near-realtime picture of Earth as your desktop background',
     long_description='himawaripy is a Python 3 script that fetches near-realtime (10 minutes delayed) picture of Earth '
                      'as its taken by Himawari 8 (ひまわり8号) and sets it as your desktop background.',
-    install_requires=["pillow", "python-dateutil", "pytz", "tzlocal"],
+    install_requires=["appdirs", "pillow", "python-dateutil", "pytz", "tzlocal"],
     packages=find_packages(),
     entry_points={'console_scripts': ['himawaripy=himawaripy.himawaripy:main']},
 )


### PR DESCRIPTION
Great little project!

I did some small changes in my fork, in case you want them back:
- various PEP8 fixes
- use the [appdirs package](https://github.com/ActiveState/appdirs) to generate download directory according to usual conventions. On Linux this gives `~/.cache/himawaripy`
