### PR TITLE
Add timeout for downloading tiles

### DIFF
--- a/himawaripy/config.py
+++ b/himawaripy/config.py
@@ -18,6 +18,9 @@ output_file = os.path.join(appdirs.user_cache_dir(appname="himawaripy",
                                                   appauthor=False),
                            "latest.png")
 
+# Deadline for the whole download process in minutes
+dl_deadline = 6
+
 # Xfce4 displays to change the background of
 xfce_displays = ["/backdrop/screen0/monitor0/image-path",
                  "/backdrop/screen0/monitor0/workspace0/last-image"]


### PR DESCRIPTION
I find it can block for hours because of some network problems. Although it's not a common situation , I think it's a good idea to add a timeout for downloading each tile. If you don't set a timeout , it may affect the next execution of the script , depending on the scheduler you are using.
