### PR TITLE
Changes for Slackware xfce

### DIFF
--- a/himawaripy/config.py
+++ b/himawaripy/config.py
@@ -2,6 +2,8 @@ import os.path
 
 import appdirs
 
+import subprocess
+
 # Increases the quality and the size. Possible values: 4, 8, 16, 20
 level = 4
 
@@ -19,5 +21,6 @@ output_file = os.path.join(appdirs.user_cache_dir(appname="himawaripy",
                            "latest.png")
 
 # Xfce4 displays to change the background of
-xfce_displays = ["/backdrop/screen0/monitor0/image-path",
-                 "/backdrop/screen0/monitor0/workspace0/last-image"]
+xfce_displays = subprocess.getoutput(
+        'xfconf-query --channel xfce4-desktop --list | grep last-image').split()
+

--- a/himawaripy/himawaripy.py
+++ b/himawaripy/himawaripy.py
@@ -12,7 +12,7 @@ from urllib.request import urlopen
 
 from PIL import Image
 from pytz import timezone
-from tzlocal import get_localzone
+from dateutil.tz import tzlocal
 
 from .config import level, output_file, auto_offset, hour_offset
 from .utils import set_background, get_desktop_environment
@@ -24,7 +24,7 @@ width = 550
 
 def get_time_offset(latest_date):
     if auto_offset:
-        local_date = datetime.now(timezone(str(get_localzone())))
+        local_date = datetime.now(tzlocal())
         himawari_date = datetime.now(timezone('Australia/Sydney'))
         local_offset = local_date.strftime("%z")
         himawari_offset = himawari_date.strftime("%z")

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     description='Put near-realtime picture of Earth as your desktop background',
     long_description='himawaripy is a Python 3 script that fetches near-realtime (10 minutes delayed) picture of Earth '
                      'as its taken by Himawari 8 (ひまわり8号) and sets it as your desktop background.',
-    install_requires=["appdirs", "pillow", "python-dateutil", "pytz", "tzlocal"],
+    install_requires=["appdirs", "pillow", "python-dateutil", "pytz"],
     packages=find_packages(),
     entry_points={'console_scripts': ['himawaripy=himawaripy.himawaripy:main']},
 )


### PR DESCRIPTION
I made a few minor changes to get this program to work on Slackware 14.2 with the xfce desktop.  Without these changes the program did not find the local timezone and it failed to set the wallpaper because property  .../monitor0/image-path does not exist.

I heard about this program on the Ubuntu UK podcast and these changes let me get the benefit of your work.

Best regards,
Bob Evans
