### PR TITLE
Retry tile download failures (time outs)

### DIFF
--- a/himawaripy/himawaripy.py
+++ b/himawaripy/himawaripy.py
@@ -54,8 +54,16 @@ def download_chunk(args):
     url_format = "http://himawari8.nict.go.jp/img/D531106/{}d/{}/{}_{}_{}.png"
     url = url_format.format(level, width, strftime("%Y/%m/%d/%H%M%S", latest), x, y)
 
-    with urlopen(url , timeout=dl_timeout) as tile_w:
-        tiledata = tile_w.read()
+    retry = 0
+    while True:
+        try:
+            with urlopen(url , timeout=dl_timeout) as tile_w:
+                tiledata = tile_w.read()
+                break
+        except Exception as e:
+            if retry > 3:
+                raise e
+            retry += 1
 
     with counter.get_lock():
         counter.value += 1


### PR DESCRIPTION
Sometimes a connection issue can cause a tile to fail, which ends the whole process.

Now, each tile is tried for download multiple times, failing after a few tries only. This has consistently worked well for me.
