### PR TITLE
Overlay Himawari output onto a specified background image

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ near-realtime picture of Earth.
       --save-battery        stop updating on battery
       --output-dir OUTPUT_DIR
                             directory to save the temporary background image
+      --composite-over COMPOSITE_OVER
+                            image to composite the background image over
+
 
 Most of the time himawaripy can accurately detect your timezone if you pass the flag `--auto-offset`, although you may
 also set it manually by `-o` (or `--offset`) flag. If your timezone is beyond GMT by more than 10 hours, use the closest
@@ -60,6 +63,8 @@ You should set a deadline compatible with your cronjob (or timer) settings to as
 minutes before it is started again.
 
 You might use `--save-battery` to disable refreshing while running on battery power.
+
+If you pass an image path with `--composite-over`, the image from himawaripy will be scaled to fit inside, centered, and pasted over it to be used as the background instead. This works great with, for example, [an image of the Milky Way](https://wallpaperscraft.com/image/milky_way_stars_space_nebula_68885_3840x2160.jpg).
 
 ### Nitrogen
 If you use nitrogen for setting your wallpaper, you have to enter this in your


### PR DESCRIPTION
This is something I've had setup for a while before I decided to clean it up and submit. I use this to mask out the image of Earth and place it centered on an image of the Milky Way as seen from Earth, and I think it significantly enhances the overall look, although this implementation accepts any image as the background.

Basically, I'm scaling and centering the Himawari image on an image that matches the size of the provided image, then making a mask to paste only the Earth portion back onto the provided image. This image is then set as the background. It's optional and only happens if an image was provided with the new `--composite-over` parameter. Invalid images or paths will quit before downloading Himawari.
