### PR TITLE
add Peppermint 7 support

### DIFF
--- a/himawaripy/utils.py
+++ b/himawaripy/utils.py
@@ -124,7 +124,7 @@ def get_desktop_environment():
     current_desktop = os.environ.get("XDG_CURRENT_DESKTOP")
     if current_desktop:
         current_desktop = current_desktop.lower()
-        if current_desktop in ["gnome", "unity", "kde", "gnome-classic", "mate"]:
+        if current_desktop in ["gnome", "unity", "kde", "gnome-classic", "mate", "lxde"]:
             return current_desktop
 
         # Special Cases

--- a/himawaripy/utils.py
+++ b/himawaripy/utils.py
@@ -109,6 +109,8 @@ def get_desktop_environment():
                 return "razor-qt"
             elif desktop_session.startswith("wmaker"):  # e.g. wmaker-common
                 return "windowmaker"
+            elif desktop_session.startswith("peppermint"):
+                return "gnome"
         if os.environ.get('KDE_FULL_SESSION') == 'true':
             return "kde"
         elif os.environ.get('GNOME_DESKTOP_SESSION_ID'):
@@ -124,7 +126,7 @@ def get_desktop_environment():
     current_desktop = os.environ.get("XDG_CURRENT_DESKTOP")
     if current_desktop:
         current_desktop = current_desktop.lower()
-        if current_desktop in ["gnome", "unity", "kde", "gnome-classic", "mate", "lxde"]:
+        if current_desktop in ["gnome", "unity", "kde", "gnome-classic", "mate"]:
             return current_desktop
 
         # Special Cases


### PR DESCRIPTION
I get:
```
Couldn't detect your desktop environment ('unknown'), but you have 'nitrogen' installed so we will use it...
Could not get bg groups from config file.
```
In python 3:
```
>>> import os
>>> os.environ.get("DESKTOP_SESSION")
'Peppermint'
>>> os.environ.get("XDG_CURRENT_DESKTOP")
'LXDE'
```
Haven't tested yet but it seems like this should do the trick.