### PR TITLE
bail out on missing "no image" tiles

### DIFF
--- a/himawaripy/__main__.py
+++ b/himawaripy/__main__.py
@@ -59,6 +59,11 @@ def download_chunk(args):
 
     tiledata = download(url)
 
+    # If the tile data is 2867 bytes, it is a blank "No Image" tile.
+    if tiledata.__sizeof__() == 2867:
+        print('No image available for {}.'.format(strftime("%Y/%m/%d %H:%M:%S", latest)))
+        os._exit(3)
+
     with counter.get_lock():
         counter.value += 1
         if counter.value == level * level:


### PR DESCRIPTION
Using the UTC offset feature can result in "No Image" tiles. himawaripy
will get the timestamp of the latest sattelite image, subtract or add
the offset, and assume an image exists for the newly calculated time.
This is correct most of the time, but occasionally results in a
timestamp for which there is no satellite image. In this case, the
service returns black tiles with the text "No Image".

These blank "No Image" tiles are always 2867 bytes (regardless of the
quality level). Legitimate tiles are always a different size (smaller if
they are the solid black surrounding Earth, larger if they are part of
Earth). By checking the size of each tile immediately after download and
bailing out if the tile is 2867 bytes, we can avoid downloading the
remaining tiles and stitching them together into a large series of "No
Image".

Exiting the program here must be done with `os._exit()` because this
part is multi-threaded. I'm using exit code 3 just so to have a unique
reason so that other programs can understand why himawaripy exited at
this point.

I've been using this for about a week now and it works great. It is
refreshing to constantly have satellite photos and not see the
occasional "No Image" interruption.

The "No Image" issue was previously discussed in #82 and #68.