### PR TITLE
Fixed systemd service file fails to execute

### DIFF
--- a/systemd/himawaripy.service
+++ b/systemd/himawaripy.service
@@ -5,4 +5,5 @@ Description=Update desktop background with satellite imagery
 
 [Service]
 Type=oneshot
-ExecStart=<INSTALLATION_PATH> # command line arguments here
+# Place command line arguments into ExecStart
+ExecStart=<INSTALLATION_PATH>


### PR DESCRIPTION
The 'command line argument' comment in `ExecStart` caused `himawaripy` to misinterpret the commend as a literal command line argument.