### PR TITLE
Fix http to https support

### DIFF
--- a/himawaripy/__main__.py
+++ b/himawaripy/__main__.py
@@ -23,6 +23,7 @@ from dateutil.tz import tzlocal
 
 from .utils import set_background, get_desktop_environment
 
+import ssl
 
 # Semantic Versioning: Major, Minor, Patch
 HIMAWARIPY_VERSION = (2, 1, 0)
@@ -55,7 +56,7 @@ def download_chunk(args):
     global counter
 
     x, y, latest, level = args
-    url_format = "http://himawari8.nict.go.jp/img/D531106/{}d/{}/{}_{}_{}.png"
+    url_format = "https://himawari8.nict.go.jp/img/D531106/{}d/{}/{}_{}_{}.png"
     url = url_format.format(level, WIDTH, strftime("%Y/%m/%d/%H%M%S", latest), x, y)
 
     tiledata = download(url)
@@ -75,7 +76,7 @@ def download_chunk(args):
 
 def parse_args():
     parser = argparse.ArgumentParser(description="set (near-realtime) picture of Earth as your desktop background",
-                                     epilog="http://labs.boramalper.org/himawaripy")
+                                     epilog="https://labs.boramalper.org/himawaripy")
 
     parser.add_argument("--version", action="version", version="%(prog)s {}.{}.{}".format(*HIMAWARIPY_VERSION))
 
@@ -130,7 +131,7 @@ def download(url):
 
     for i in range(1, 4):  # retry max 3 times
         try:
-            with urllib.request.urlopen(url) as response:
+            with urllib.request.urlopen(url, context=ssl.SSLContext(ssl.PROTOCOL_TLS)) as response:
                 return response.read()
         except Exception as e:
             exception = e
@@ -151,7 +152,7 @@ def thread_main(args):
     level = args.level  # since we are going to use it a lot of times
 
     print("Updating...")
-    latest_json = download("http://himawari8-dl.nict.go.jp/himawari8/img/D531106/latest.json")
+    latest_json = download("https://himawari8-dl.nict.go.jp/himawari8/img/D531106/latest.json")
     latest = strptime(json.loads(latest_json.decode("utf-8"))["date"], "%Y-%m-%d %H:%M:%S")
 
     print("Latest version: {} GMT.".format(strftime("%Y/%m/%d %H:%M:%S", latest)))


### PR DESCRIPTION
Himawari official site announces that http service is finished by the end of September.

So himawaripy must change protocol from http to https.

![announce](https://user-images.githubusercontent.com/15080890/92292385-f6cc5180-ef57-11ea-8923-f48c53ca3813.png)
